### PR TITLE
@media queries: css3 conformity

### DIFF
--- a/pgmapcss/parser/check_media_query.py
+++ b/pgmapcss/parser/check_media_query.py
@@ -33,6 +33,9 @@ def check_media_query(stat, to_parse, query):
                     if len(VERSION_INFO) < i or (type(VERSION_INFO[i]) == int and VERSION_INFO[i] > int(v)):
                         m1 = False
 
+            elif q[0] == 'type':
+                m1 = True
+
             if not m1:
                 match1 = False
 

--- a/pgmapcss/parser/parse_defines.py
+++ b/pgmapcss/parser/parse_defines.py
@@ -37,7 +37,14 @@ def parse_defines(stat, to_parse):
                     parse_mode = 1
 
                 if parse_mode == 1:
-                    if to_parse.match('\s*\(\s*([a-zA-Z\-0-9]+)\s*(:\s*([^\)]+))?\s*\)'):
+                    if to_parse.match('\s*([a-zA-Z\-0-9]+)'):
+                        query[-1].append((
+                            'type',
+                            to_parse.match_group(1)
+                        ))
+                        parse_mode = 2
+
+                    elif to_parse.match('\s*\(\s*([a-zA-Z\-0-9]+)\s*(:\s*([^\)]+))?\s*\)'):
                         query[-1].append((
                             to_parse.match_group(1),
                             to_parse.match_group(3)
@@ -45,7 +52,7 @@ def parse_defines(stat, to_parse):
                         parse_mode = 2
 
                     else:
-                        raise ParseError(to_parse, 'Error parsing @media query, expecting feature query')
+                        raise ParseError(to_parse, 'Error parsing @media query, expecting feature or type query')
 
                 if parse_mode == 2:
                     if to_parse.match('\s*({|and|,)'):


### PR DESCRIPTION
"not" is a prefix for a media query part, but can not be used for single elements. Therefore it's not valid to do `@media (user-agent: pgmapcss) and not (min-pgmapcss-version: 0.8)`.
