### PR TITLE
Eval with fake_plpy

### DIFF
--- a/pgmapcss/compiler/compile_function_match.py
+++ b/pgmapcss/compiler/compile_function_match.py
@@ -63,8 +63,9 @@ def compile_function_match(stat):
       'eval_functions': \
 resource_string(pgmapcss.eval.__name__, 'base.py').decode('utf-8') +\
 pgmapcss.eval.functions().print(indent='') +\
-include_text()
+include_text(),
     }
+    replacement['fake_plpy'] = strip_includes(resource_stream(pgmapcss.misc.__name__, 'fake_plpy.py'), stat).format(**replacement)
     # add all config options as replacement patterns, in the form
     # 'config|foo|bar', were 'foo.bar' was the config option ('.' not allowed
     # in patterns)

--- a/pgmapcss/misc/fake_plpy.py
+++ b/pgmapcss/misc/fake_plpy.py
@@ -1,0 +1,68 @@
+class fake_plpy:
+    def __init__(self, args=None):
+        self.conn = postgresql.open(
+            host=(args.host if args and args.host else '{host}'),
+            password=(args.password if args and args.password else '{password}'),
+            database=(args.database if args and args.database else '{database}'),
+            user=(args.user if args and args.user else '{user}')
+        )
+        self.conn.settings.update({{
+# START db.search_path
+            'search_path': "{config|db|search_path}"
+# END db.search_path
+        }})
+# START debug.explain_queries
+        self.explain_queries = {{ }}
+# END debug.explain_queries
+
+    def notice(self, *arg):
+        sys.stderr.write('NOTICE: ' + ' '.join([repr(a) for a in arg]) + '\n')
+
+    def warning(self, *arg):
+        sys.stderr.write('WARNING: ' + ' '.join([repr(a) for a in arg]) + '\n')
+
+    def prepare(self, query, param_type):
+        for (i, t) in enumerate(param_type):
+            i1 = i + 1
+            if t == 'geometry':
+                t = 'text'
+            elif t == 'geometry[]':
+                t = 'text[]'
+            query = query.replace('$' + str(i1), '$' + str(i1) + '::' + t)
+
+        plan = self.conn.prepare(query)
+        plan.query = query
+
+        return plan
+
+    def execute(self, plan, param=[]):
+# START debug.explain_queries
+        if not plan.query in self.explain_queries:
+            self.explain_queries[plan.query] = {{ 'count': 0 }}
+            explain = self.conn.prepare('explain ' + plan.query)
+            sys.stderr.write(plan.query)
+            self.explain_queries[plan.query]['explain'] = explain(*param)
+
+        self.explain_queries[plan.query]['count'] += 1
+# END debug.explain_queries
+        ret = []
+        for r in plan(*param):
+            if type(r) != postgresql.types.Row:
+                return r
+
+            ret.append(dict(r))
+
+        return ret
+
+    def cursor(self, plan, param=[]):
+# START debug.explain_queries
+        if not plan.query in self.explain_queries:
+            self.explain_queries[plan.query] = {{ 'count': 0 }}
+            explain = self.conn.prepare('explain ' + plan.query)
+            sys.stderr.write(plan.query)
+            self.explain_queries[plan.query]['explain'] = explain(*param)
+
+        self.explain_queries[plan.query]['count'] += 1
+# END debug.explain_queries
+        for r in plan(*param):
+            yield dict(r)

--- a/pgmapcss/mode/standalone/header.inc
+++ b/pgmapcss/mode/standalone/header.inc
@@ -4,75 +4,7 @@ import postgresql
 import sys
 import math
 
-class fake_plpy:
-    def __init__(self, args=None):
-        self.conn = postgresql.open(
-            host=(args.host if args and args.host else '{host}'),
-            password=(args.password if args and args.password else '{password}'),
-            database=(args.database if args and args.database else '{database}'),
-            user=(args.user if args and args.user else '{user}')
-        )
-        self.conn.settings.update({{
-# START db.search_path
-            'search_path': "{config|db|search_path}"
-# END db.search_path
-        }})
-# START debug.explain_queries
-        self.explain_queries = {{ }}
-# END debug.explain_queries
-
-    def notice(self, *arg):
-        sys.stderr.write('NOTICE: ' + ' '.join([repr(a) for a in arg]) + '\n')
-
-    def warning(self, *arg):
-        sys.stderr.write('WARNING: ' + ' '.join([repr(a) for a in arg]) + '\n')
-
-    def prepare(self, query, param_type):
-        for (i, t) in enumerate(param_type):
-            i1 = i + 1
-            if t == 'geometry':
-                t = 'text'
-            elif t == 'geometry[]':
-                t = 'text[]'
-            query = query.replace('$' + str(i1), '$' + str(i1) + '::' + t)
-
-        plan = self.conn.prepare(query)
-        plan.query = query
-
-        return plan
-
-    def execute(self, plan, param=[]):
-# START debug.explain_queries
-        if not plan.query in self.explain_queries:
-            self.explain_queries[plan.query] = {{ 'count': 0 }}
-            explain = self.conn.prepare('explain ' + plan.query)
-            sys.stderr.write(plan.query)
-            self.explain_queries[plan.query]['explain'] = explain(*param)
-
-        self.explain_queries[plan.query]['count'] += 1
-# END debug.explain_queries
-        ret = []
-        for r in plan(*param):
-            if type(r) != postgresql.types.Row:
-                return r
-
-            ret.append(dict(r))
-
-        return ret
-
-    def cursor(self, plan, param=[]):
-# START debug.explain_queries
-        if not plan.query in self.explain_queries:
-            self.explain_queries[plan.query] = {{ 'count': 0 }}
-            explain = self.conn.prepare('explain ' + plan.query)
-            sys.stderr.write(plan.query)
-            self.explain_queries[plan.query]['explain'] = explain(*param)
-
-        self.explain_queries[plan.query]['count'] += 1
-# END debug.explain_queries
-        for r in plan(*param):
-            yield dict(r)
+{fake_plpy}
 
 def pgmapcss_{style_id}(bbox=None, scale_denominator=2000, parameters={{}}, _all_style_elements={all_style_elements}):
     import pghstore
-    plpy = fake_plpy()


### PR DESCRIPTION
During compiling the eval functions will be called to guess possible result values, but not within the context of a database functions, though many eval functions need access to the module plpy. Use fake_plpy (from mode standalone) to emulate plpy.